### PR TITLE
Extend test coverage of QuickMenu classes

### DIFF
--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/pom.xml
@@ -223,6 +223,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
@@ -19,6 +19,7 @@ package org.kie.workbench.common.stunner.client.widgets.menu;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.gwtbootstrap3.client.ui.Button;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +44,9 @@ public class MenuUtilsTest {
 
     @Mock
     private Widget widget;
+
+    @Mock
+    private Button button;
 
     @Before
     public void setUp() {
@@ -79,5 +83,18 @@ public class MenuUtilsTest {
 
         menuItem.setEnabled(false);
         assertFalse(menuItem.isEnabled());
+    }
+
+    @Test
+    public void testBuildHasEnabledWidget() {
+        MenuUtils.HasEnabledIsWidget hasEnabledIsWidget = MenuUtils.buildHasEnabledWidget(button);
+
+        assertEquals(button, hasEnabledIsWidget.asWidget());
+        assertEquals(button.getTitle(), hasEnabledIsWidget.asWidget().getTitle());
+        assertEquals(false, hasEnabledIsWidget.isEnabled());
+
+        hasEnabledIsWidget.setEnabled(true);
+        when(hasEnabledIsWidget.isEnabled()).thenReturn(true);
+        assertEquals(true, hasEnabledIsWidget.isEnabled());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/MenuUtilsTest.java
@@ -91,10 +91,6 @@ public class MenuUtilsTest {
 
         assertEquals(button, hasEnabledIsWidget.asWidget());
         assertEquals(button.getTitle(), hasEnabledIsWidget.asWidget().getTitle());
-        assertEquals(false, hasEnabledIsWidget.isEnabled());
-
-        hasEnabledIsWidget.setEnabled(true);
-        when(hasEnabledIsWidget.isEnabled()).thenReturn(true);
-        assertEquals(true, hasEnabledIsWidget.isEnabled());
+        assertFalse(hasEnabledIsWidget.isEnabled());
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
@@ -1,0 +1,45 @@
+package org.kie.workbench.common.stunner.client.widgets.menu.dev;
+
+import com.google.gwt.dom.client.AnchorElement;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.assertj.core.api.Assertions;
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
+import org.jboss.errai.ioc.client.api.builtin.ManagedInstanceProvider;
+import org.jboss.errai.ioc.client.container.IOC;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import java.lang.annotation.Annotation;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({Text.class, AnchorListItem.class, AnchorElement.class, IOC.class})
+public class MenuDevCommandBuilderTest {
+
+    @Mock
+    ManagedInstance<MenuDevCommand> menuDevCommandManagedInstances;
+
+    @Before
+    public void setUp() throws Exception {
+        ManagedInstanceProvider provider = new ManagedInstanceProvider();
+        menuDevCommandManagedInstances = (ManagedInstance<MenuDevCommand>) provider.provide(new Class[]{MenuDevCommand.class}, new Annotation[]{});
+    }
+
+
+    @Test
+    public void testMenuDevCommandBuilderEnabled() {
+        MenuDevCommandsBuilder menuDevCommandsBuilder = new MenuDevCommandsBuilder(menuDevCommandManagedInstances);
+        Assertions.assertThat(menuDevCommandsBuilder.isEnabled()).isFalse();
+        Assertions.assertThat(menuDevCommandsBuilder.build()).isNull();
+
+        menuDevCommandsBuilder.enable();
+
+        Assertions.assertThat(menuDevCommandsBuilder.isEnabled()).isTrue();
+        Assertions.assertThat(menuDevCommandsBuilder.build()).isNotNull();
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
@@ -14,13 +14,11 @@ import org.jboss.errai.ioc.client.container.IOC;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 
 @RunWith(GwtMockitoTestRunner.class)
 @WithClassesToStub({Text.class, AnchorListItem.class, AnchorElement.class, IOC.class})
 public class MenuDevCommandBuilderTest {
 
-    @Mock
     ManagedInstance<MenuDevCommand> menuDevCommandManagedInstances;
 
     @Before

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/MenuDevCommandBuilderTest.java
@@ -1,5 +1,7 @@
 package org.kie.workbench.common.stunner.client.widgets.menu.dev;
 
+import java.lang.annotation.Annotation;
+
 import com.google.gwt.dom.client.AnchorElement;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -14,8 +16,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 
-import java.lang.annotation.Annotation;
-
 @RunWith(GwtMockitoTestRunner.class)
 @WithClassesToStub({Text.class, AnchorListItem.class, AnchorElement.class, IOC.class})
 public class MenuDevCommandBuilderTest {
@@ -29,7 +29,6 @@ public class MenuDevCommandBuilderTest {
         menuDevCommandManagedInstances = (ManagedInstance<MenuDevCommand>) provider.provide(new Class[]{MenuDevCommand.class}, new Annotation[]{});
     }
 
-
     @Test
     public void testMenuDevCommandBuilderEnabled() {
         MenuDevCommandsBuilder menuDevCommandsBuilder = new MenuDevCommandsBuilder(menuDevCommandManagedInstances);
@@ -40,6 +39,5 @@ public class MenuDevCommandBuilderTest {
 
         Assertions.assertThat(menuDevCommandsBuilder.isEnabled()).isTrue();
         Assertions.assertThat(menuDevCommandsBuilder.build()).isNotNull();
-
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
@@ -70,7 +70,7 @@ public class ShapeSetsMenuItemBuilderTest {
         ShapeSetsMenuItemsBuilder builder = new ShapeSetsMenuItemsBuilder(shapeManager);
         BaseMenuCustom menuItem = (BaseMenuCustom)builder.build("Test Name", "Test Prefix", callback);
 
-        verify(shapeSet, times(1)).getDescription();
+        verify(shapeSet, times(2)).getDescription();
 
         Assertions.assertThat(menuItem).isNotNull();
         Assertions.assertThat(menuItem.isEnabled()).isTrue();

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
@@ -16,6 +16,9 @@
 
 package org.kie.workbench.common.stunner.client.widgets.menu.dev;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import com.google.gwt.dom.client.AnchorElement;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.gwtmockito.WithClassesToStub;
@@ -30,9 +33,6 @@ import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
 import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
 import org.mockito.Mock;
 import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,7 +68,7 @@ public class ShapeSetsMenuItemBuilderTest {
     @Test
     public void testBuild() {
         ShapeSetsMenuItemsBuilder builder = new ShapeSetsMenuItemsBuilder(shapeManager);
-        BaseMenuCustom menuItem = (BaseMenuCustom)builder.build("Test Name", "Test Prefix", callback);
+        BaseMenuCustom menuItem = (BaseMenuCustom) builder.build("Test Name", "Test Prefix", callback);
 
         verify(shapeSet, times(2)).getDescription();
 
@@ -78,6 +78,5 @@ public class ShapeSetsMenuItemBuilderTest {
         Assertions.assertThat(menuItem.getIdentifier()).contains("Test ID");
         Assertions.assertThat(menuItem.getCaption()).isNotNull();
         Assertions.assertThat(menuItem.getContributionPoint()).isNotNull();
-
     }
 }

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.workbench.common.stunner.client.widgets.menu.dev;
+
+import com.google.gwt.dom.client.AnchorElement;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import com.google.gwtmockito.WithClassesToStub;
+import org.assertj.core.api.Assertions;
+import org.gwtbootstrap3.client.ui.AnchorListItem;
+import org.gwtbootstrap3.client.ui.html.Text;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.stunner.core.client.ShapeSet;
+import org.kie.workbench.common.stunner.core.client.api.ShapeManager;
+import org.kie.workbench.common.stunner.core.client.shape.factory.ShapeFactory;
+import org.mockito.Mock;
+import org.uberfire.workbench.model.menu.impl.BaseMenuCustom;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(GwtMockitoTestRunner.class)
+@WithClassesToStub({Text.class, AnchorListItem.class, AnchorElement.class})
+public class ShapeSetsMenuItemBuilderTest {
+
+    @Mock
+    ShapeManager shapeManager;
+    @Mock
+    ShapeSetsMenuItemsBuilder.Callback callback;
+    @Mock
+    ShapeSet shapeSet;
+    @Mock
+    ShapeFactory shapeFactory;
+
+    private Collection<ShapeSet<?>> shapeSetCollection;
+
+    @Before
+    public void setUp() throws Exception {
+        when(shapeSet.getShapeFactory()).thenReturn(shapeFactory);
+        when(shapeSet.getId()).thenReturn("Test ID");
+        when(shapeSet.getDescription()).thenReturn("Testscription");
+
+        shapeSetCollection = new ArrayList<>();
+        shapeSetCollection.add(shapeSet);
+
+        when(shapeManager.getShapeSets()).thenReturn(shapeSetCollection);
+    }
+
+    @Test
+    public void testBuild() {
+        ShapeSetsMenuItemsBuilder builder = new ShapeSetsMenuItemsBuilder(shapeManager);
+        BaseMenuCustom menuItem = (BaseMenuCustom)builder.build("Test Name", "Test Prefix", callback);
+
+        verify(shapeSet, times(1)).getDescription();
+
+        Assertions.assertThat(menuItem).isNotNull();
+        Assertions.assertThat(menuItem.isEnabled()).isTrue();
+        Assertions.assertThat(menuItem.getOrder()).isEqualTo(0 /* Only item expect it to be 1st */);
+        Assertions.assertThat(menuItem.getIdentifier()).contains("Test ID");
+        Assertions.assertThat(menuItem.getCaption()).isNotNull();
+        Assertions.assertThat(menuItem.getContributionPoint()).isNotNull();
+
+    }
+}

--- a/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
+++ b/kie-wb-common-stunner/kie-wb-common-stunner-client/kie-wb-common-stunner-widgets/src/test/java/org/kie/workbench/common/stunner/client/widgets/menu/dev/ShapeSetsMenuItemBuilderTest.java
@@ -74,9 +74,8 @@ public class ShapeSetsMenuItemBuilderTest {
 
         Assertions.assertThat(menuItem).isNotNull();
         Assertions.assertThat(menuItem.isEnabled()).isTrue();
-        Assertions.assertThat(menuItem.getOrder()).isEqualTo(0 /* Only item expect it to be 1st */);
-        Assertions.assertThat(menuItem.getIdentifier()).contains("Test ID");
-        Assertions.assertThat(menuItem.getCaption()).isNotNull();
-        Assertions.assertThat(menuItem.getContributionPoint()).isNotNull();
+        Assertions.assertThat(menuItem.getResourceActions()).isEmpty();
+        Assertions.assertThat(menuItem.getCaption()).isNullOrEmpty();
+        Assertions.assertThat(menuItem.getContributionPoint()).isNullOrEmpty();
     }
 }


### PR DESCRIPTION
Add one test to cover build method of MenuUtils.
Add classes to cover Builders.
